### PR TITLE
fix: Switch Ubuntu to an LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
+# Switch to ROOT mode
 USER root
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends --fix-missing openssh-server vim build-essential git golang ca-certificates iputils-ping curl netcat nodejs npm
-RUN npm install web3 express
+
+# Create a non-root user (for later usage by this Dockerfile)
 RUN useradd -m -s /bin/bash ethuser
 
+RUN apt-get update
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get install -y --no-install-recommends --fix-missing openssh-server vim build-essential git golang ca-certificates iputils-ping curl netcat nodejs npm
+
+# Define the WORKDIR, because recent versions of NodeJS and NPM require it
+# Otherwise packages are installed at the container root folder
 WORKDIR /home/ethuser
+
+# Switch to the LTS version of NodeJS
+RUN npm install -g n && n lts
+
+# Install required packages
+RUN npm install web3 express
+
+# Switch to the non-root user for subsequent commands
 USER ethuser
+
 RUN mkdir data config
 RUN git clone https://github.com/ethereum/go-ethereum
-RUN cd go-ethereum && make all
+RUN cd go-ethereum && make geth && make all
 COPY --chown=ethuser config /home/ethuser/config
 USER root
 RUN cp /home/ethuser/go-ethereum/build/bin/* /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 USER root
 RUN apt-get update


### PR DESCRIPTION
The current implementation was pointing to Ubuntu version 18.10 which is no longer supported and the `apt-get update` command fails. As a result, following the README and running the ./build.sh command - it also fails.