### PR TITLE
Fixed the build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ USER root
 RUN useradd -m -s /bin/bash ethuser
 
 RUN apt-get update
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get install -y --no-install-recommends --fix-missing openssh-server vim build-essential git golang ca-certificates iputils-ping curl netcat nodejs npm
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get install -y --no-install-recommends --fix-missing openssh-server vim build-essential git ca-certificates iputils-ping curl netcat nodejs npm wget
+RUN wget https://golang.org/dl/go1.15.2.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.15.2.linux-amd64.tar.gz
+RUN export PATH=$PATH:/usr/local/go/bin
+RUN echo 'export PATH=$PATH:/usr/local/go/bin' >> /root/.bashrc
+RUN echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/ethuser/.bashrc
 
 # Define the WORKDIR, because recent versions of NodeJS and NPM require it
 # Otherwise packages are installed at the container root folder
@@ -24,7 +28,8 @@ USER ethuser
 
 RUN mkdir data config
 RUN git clone https://github.com/ethereum/go-ethereum
-RUN cd go-ethereum && make geth && make all
+RUN cd go-ethereum && make geth
+RUN cd go-ethereum && make all
 COPY --chown=ethuser config /home/ethuser/config
 USER root
 RUN cp /home/ethuser/go-ethereum/build/bin/* /usr/local/bin


### PR DESCRIPTION
I ran into this error while building (on two different machines)

```
....
github.com/aws/aws-sdk-go-v2/service/sts
github.com/aws/aws-sdk-go-v2/credentials/endpointcreds
github.com/stretchr/testify/assert
github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds
github.com/aws/aws-sdk-go-v2/credentials/ssocreds
# github.com/aws/aws-sdk-go-v2/service/route53
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:671:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:849:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1048:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1223:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1395:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1558:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1724:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
../go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/route53@v1.1.1/deserializers.go:1890:36: response.Response.Header.Values undefined (type "net/http".Header has no field or method Values)
note: module requires Go 1.15
github.com/ethereum/go-ethereum/cmd/devp2p/internal/ethtest
github.com/aws/aws-sdk-go-v2/credentials/stscreds
github.com/aws/aws-sdk-go-v2/config
util.go:47: exit status 2
exit status 1
make: *** [Makefile:21: all] Error 1
....
```

The solution I found was to upgrade golang, but seeing as Ubuntu 20.04 doesn't have a native package in its repository I manually installed it.

